### PR TITLE
Running test_method_wait using subprocess doesn't seem to work correctly.

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,11 +6,10 @@
 import unittest
 import typing
 import asyncio
-import asyncio.subprocess
 import random
 import string
-import subprocess
 import time
+from multiprocessing import Process
 
 import adbus
 
@@ -34,13 +33,16 @@ class Test(unittest.TestCase):
         return random.randint(-2000, 2000)
 
     @classmethod
+    def run_test_wait(cls):
+        import test_server
+        test_server.Test.setUpClass()
+        test = test_server.Test()
+        test.test_method_wait()
+
+    @classmethod
     def setUpClass(cls):
-        cls.server = subprocess.Popen(
-                [
-                        'python', '-m', 'unittest',
-                        'tests.test_server.Test.test_method_wait'
-                ]
-        )
+        cls.server = Process(target=cls.run_test_wait, name='run_test_wait')
+        cls.server.start()
         time.sleep(3)
 
         cls.loop = asyncio.get_event_loop()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ import asyncio.subprocess
 import typing
 import time
 import sys
+from multiprocessing import current_process
 
 import adbus
 
@@ -198,7 +199,8 @@ class Test(unittest.TestCase):
         )
 
     @unittest.skipIf(
-            "tests.test_server.Test.test_method_wait" not in sys.argv,
+            "tests.test_server.Test.test_method_wait" not in sys.argv and \
+            current_process().name != "run_test_wait",
             "long test used for development"
     )
     def test_method_wait(self):


### PR DESCRIPTION
Instead we can use multiprocessing which is more reliable.