### PR TITLE
Fix timeout on calling an dbus activatable service

### DIFF
--- a/adbus/sdbus/service.pxi
+++ b/adbus/sdbus/service.pxi
@@ -56,7 +56,7 @@ cdef class Service:
         if not loop:
             loop = get_event_loop()
 
-        loop.add_reader(bus_fd, self.process)
+        loop.add_writer(hus_fd, self.process)
 
         self.loop = loop
 


### PR DESCRIPTION
This commit fixes #61 where the first method call will timeout on an dbus activatable service.

Signed-off-by: Lars Pedersen <lapeddk@gmail.com>