### PR TITLE
Add expect reply option to dbus calls

### DIFF
--- a/adbus/client/call.py
+++ b/adbus/client/call.py
@@ -11,7 +11,8 @@ async def call(
         method,
         args=(),
         response_signature=None,
-        timeout_ms=30000
+        timeout_ms=30000,
+        expect_reply=True,
 ):
     """Calls a D-Bus Method in another process.
 
@@ -27,7 +28,8 @@ async def call(
         response_signature (str): optional, D-Bus Signature of the expected
             response, if None the signature will be created at run-time,
             specifying it here will speed up the message post-processing
-        timeout_ms (int): maximum time to wait for a response in milli-seconds
+        timeout_ms (int): optional, maximum time to wait for a response in milli-seconds
+        expect_reply (bool): optional, expect a method call reply
 
     """
 
@@ -38,7 +40,7 @@ async def call(
 
     call = sdbus.Call(
             service.sdbus, address.encode(), path.encode(), interface.encode(),
-            method.encode(), args, _response_signature
+            method.encode(), args, _response_signature, expect_reply
     )
 
     call.send(timeout_ms)

--- a/adbus/sdbus/message.pxi
+++ b/adbus/sdbus/message.pxi
@@ -35,7 +35,7 @@ cdef class Message:
         self.message = sdbus_h.sd_bus_message_ref(message)
 
     cdef new_method_call(self, Service service, char *destination,
-            char *path, char *interface, const char *member):
+            char *path, char *interface, const char *member, bint expect_reply):
         cdef int ret
 
         self.message = sdbus_h.sd_bus_message_unref(self.message)
@@ -44,6 +44,10 @@ cdef class Message:
         if ret < 0:
             raise SdbusError(
                 f"Failed to create new method call: {errorcode[-ret]}", -ret)
+        ret = sdbus_h.sd_bus_message_set_expect_reply(self.message, expect_reply)
+        if ret < 0:
+            raise SdbusError(
+                f"Failed to set message expect reply: {expect_reply}. Error: {errorcode[-ret]}", expect_reply, -ret)
 
     cdef new_method_return(self):
         cdef int ret

--- a/adbus/sdbus_h.pxd
+++ b/adbus/sdbus_h.pxd
@@ -142,6 +142,7 @@ cdef extern from "systemd/sd-bus.h":
     int sd_bus_message_new_method_call(sd_bus *bus, sd_bus_message **m,
             const char *destination, const char *path, const char *interface,
             const char *member)
+    int sd_bus_message_set_expect_reply(sd_bus_message *m, int expect_reply)
 
     const char *sd_bus_message_get_signature(sd_bus_message *m, int complete)
     int sd_bus_message_read_basic(sd_bus_message *m, char type, void *p)


### PR DESCRIPTION
Added expect reply option for method calls like the one in systemd busctl

busctl --help
busctl [OPTIONS...] COMMAND ...
--expect-reply=BOOL   Expect a method call reply

Signed-off-by: Lars Pedersen <lapeddk@gmail.com>