### PR TITLE
Update regex in camel_to_snake

### DIFF
--- a/adbus/__version__.py
+++ b/adbus/__version__.py
@@ -1,3 +1,3 @@
-# == Copyright: 2017-2022, CCX Technologies
+# == Copyright: 2017-2023, CCX Technologies
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/adbus/sdbus/snake.pxi
+++ b/adbus/sdbus/snake.pxi
@@ -12,8 +12,7 @@ def snake_to_camel(snake):
     """
     return "".join(x[:1].upper() + x[1:] for x in snake.split("_"))
 
-first_cap_re = re.compile('(.)([A-Z][a-z]+)')
-all_cap_re = re.compile('([a-z0-9])([A-Z])')
+cap_re = re.compile('(?<!^)(?=[A-Z])')
 def camel_to_snake(camel):
     """Converts CamelCase separated string to snake_case.
 
@@ -23,5 +22,5 @@ def camel_to_snake(camel):
     Returns:
         A string in snake_case.
     """
-    s1 = first_cap_re.sub(r'\1_\2', camel)
-    return all_cap_re.sub(r'\1_\2', s1).lower()
+    s1 = cap_re.sub('_', camel)
+    return s1.lower()

--- a/adbus/sdbus/snake.pxi
+++ b/adbus/sdbus/snake.pxi
@@ -1,4 +1,4 @@
-# Copyright: 2017, CCX Technologies
+# Copyright: 2017-2023, CCX Technologies
 #cython: language_level=3
 
 def snake_to_camel(snake):

--- a/tests/test_sdbus_snake.py
+++ b/tests/test_sdbus_snake.py
@@ -33,9 +33,6 @@ class Test(unittest.TestCase):
         c = camel_to_snake("Test_One")
         self.assertEqual(c, "test__one")
 
-        c = camel_to_snake("testOne")
-        self.assertEqual(c, "test_one")
-
         c = camel_to_snake("TestOneTwoThree")
         self.assertEqual(c, "test_one_two_three")
 

--- a/tests/test_sdbus_snake.py
+++ b/tests/test_sdbus_snake.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright: 2017, CCX Technologies
+# Copyright: 2017-2023, CCX Technologies
 """Test of low-level sd-bus snake and camel conversion utilities"""
 
 import unittest

--- a/tests/test_sdbus_snake.py
+++ b/tests/test_sdbus_snake.py
@@ -39,6 +39,12 @@ class Test(unittest.TestCase):
         c = camel_to_snake("TTestOne")
         self.assertEqual(c, "t_test_one")
 
+        c = camel_to_snake("OneABCTest")
+        self.assertEqual(c, "one_a_b_c_test")
+
+        c = camel_to_snake("DataA11BC")
+        self.assertEqual(c, "data_a11_b_c")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Issue:** https://github.com/ccxtechnologies/builder/issues/3046
camel_to_snake wasn't working for a specific property name (M1553TR was converted to m1553_tr instead of m1553_t_r)

**Solution:**
1. Change regular expression, so it now works for the above case (and continues working for all other cases).
2. Also added more test cases to test_sdbus_snake.py

**Other considered solutions:**
described in [this comment](https://github.com/ccxtechnologies/builder/issues/3046#issuecomment-1535056811)

**Testing:**
- with ipython:
![Screenshot from 2023-05-04 13-07-28](https://user-images.githubusercontent.com/112961886/236301680-2c0ff2ff-3f4e-4e55-808a-cc5da89ce193.png)

- in regex101:
![image](https://user-images.githubusercontent.com/112961886/236301956-b1dc8cfb-f32e-4153-adf5-59634921945e.png)

- on AP250:
_to_be_updated_