### PR TITLE
Bug threadsafe coroutine

### DIFF
--- a/adbus/__version__.py
+++ b/adbus/__version__.py
@@ -1,3 +1,3 @@
 # == Copyright: 2017-2025, CCX Technologies
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"

--- a/adbus/sdbus/service.pxi
+++ b/adbus/sdbus/service.pxi
@@ -1,6 +1,8 @@
 # Copyright: 2017-2021, CCX Technologies
 #cython: language_level=3
 
+import threading
+
 cdef class Service:
     cdef sdbus_h.sd_bus *bus
     cdef bytes name
@@ -12,7 +14,8 @@ cdef class Service:
     cdef object startup_task
 
     def __cinit__(self, name=None, loop=None, bus='system',
-            replace_existing=False, allow_replacement=False, queue=False):
+            replace_existing=False, allow_replacement=False, queue=False,
+            thread_id=0):
         cdef const char *unique
 
         if name:
@@ -57,10 +60,12 @@ cdef class Service:
 
         if not loop:
             loop = get_event_loop()
+            thread_id = threading.get_ident()
 
         self.process_loop = True
         self.startup_task = loop.create_task(self.startup_process())
         loop.add_reader(bus_fd, self.process)
+        loop._ccx_thread_id = thread_id
 
         self.loop = loop
 

--- a/adbus/sdbus/service.pxi
+++ b/adbus/sdbus/service.pxi
@@ -1,4 +1,4 @@
-# Copyright: 2017-2021, CCX Technologies
+# Copyright: 2017-2025, CCX Technologies
 #cython: language_level=3
 
 import threading

--- a/adbus/server/object.py
+++ b/adbus/server/object.py
@@ -79,7 +79,7 @@ class Object:
 
         elif self.service.is_running():
             _loop = self.service.get_loop()
-            if _loop._thread_id != threading.get_ident():
+            if _loop._ccx_thread_id != threading.get_ident():
                 asyncio.run_coroutine_threadsafe(
                         self.sdbus.emit_properties_changed(
                                 [dbus_name.encode()]
@@ -105,7 +105,7 @@ class Object:
             self._defer_properties = False
             if self._deferred_property_signals:
                 _loop = self.service.get_loop()
-                if _loop._thread_id != threading.get_ident():
+                if _loop._ccx_thread_id != threading.get_ident():
                     asyncio.run_coroutine_threadsafe(
                             self.sdbus.emit_properties_changed(
                                     list(

--- a/adbus/server/object.py
+++ b/adbus/server/object.py
@@ -1,7 +1,8 @@
-# Copyright: 2017, CCX Technologies
+# Copyright: 2017-2025, CCX Technologies
 """D-Bus Object"""
 
 import asyncio
+import threading
 
 from .. import sdbus
 
@@ -77,10 +78,21 @@ class Object:
             self._deferred_property_signals[dbus_name.encode()] = True
 
         elif self.service.is_running():
-            asyncio.run_coroutine_threadsafe(
-                    self.sdbus.emit_properties_changed([dbus_name.encode()]),
-                    loop=self.service.get_loop()
-            )
+            _loop = self.service.get_loop()
+            if _loop._thread_id != threading.get_ident():
+                asyncio.run_coroutine_threadsafe(
+                        self.sdbus.emit_properties_changed(
+                                [dbus_name.encode()]
+                        ),
+                        loop=_loop
+                )
+            else:
+                asyncio.ensure_future(
+                        self.sdbus.emit_properties_changed(
+                                [dbus_name.encode()]
+                        ),
+                        loop=_loop
+                )
 
     def defer_property_updates(self, enable):
         if enable:
@@ -92,12 +104,27 @@ class Object:
 
             self._defer_properties = False
             if self._deferred_property_signals:
-                asyncio.run_coroutine_threadsafe(
-                        self.sdbus.emit_properties_changed(
-                                list(self._deferred_property_signals.keys())
-                        ),
-                        loop=self.service.get_loop()
-                )
+                _loop = self.service.get_loop()
+                if _loop._thread_id != threading.get_ident():
+                    asyncio.run_coroutine_threadsafe(
+                            self.sdbus.emit_properties_changed(
+                                    list(
+                                            self._deferred_property_signals.
+                                            keys()
+                                    )
+                            ),
+                            loop=_loop
+                    )
+                else:
+                    asyncio.ensure_future(
+                            self.sdbus.emit_properties_changed(
+                                    list(
+                                            self._deferred_property_signals.
+                                            keys()
+                                    )
+                            ),
+                            loop=_loop
+                    )
 
                 self._deferred_property_signals = {}
 

--- a/adbus/server/property.py
+++ b/adbus/server/property.py
@@ -77,8 +77,8 @@ class Property:
             self.emit_changed(instance)
 
     def emit_changed(self, instance):
-        if self.hidden:
-            return
+        #if self.hidden:
+        #    return
 
         if self.emits_change or self.emits_invalidation:
             instance.emit_property_changed(self.dbus_name)

--- a/adbus/server/property.py
+++ b/adbus/server/property.py
@@ -77,8 +77,8 @@ class Property:
             self.emit_changed(instance)
 
     def emit_changed(self, instance):
-        #if self.hidden:
-        #    return
+        if self.hidden:
+            return
 
         if self.emits_change or self.emits_invalidation:
             instance.emit_property_changed(self.dbus_name)

--- a/adbus/service.py
+++ b/adbus/service.py
@@ -1,4 +1,4 @@
-# Copyright: 2017, CCX Technologies
+# Copyright: 2017-2025, CCX Technologies
 """D-Bus Service"""
 
 from . import sdbus

--- a/adbus/service.py
+++ b/adbus/service.py
@@ -23,6 +23,8 @@ class Service:
         name_queue (bool): optional, if our name is in use by another
             service put ourselves in the D-Bus name queue, we will get
             name once the existing service relinquishes it
+        thread_id: optional, the thread id associated with the loop. If the
+            loop is not defined, will use threading.get_ident()
 
     Raises:
         BusError: if an error occurs during initialization
@@ -35,11 +37,12 @@ class Service:
             bus='system',
             replace_existing=False,
             allow_replacement=False,
-            name_queue=False
+            name_queue=False,
+            thread_id=0
     ):
         self.sdbus = sdbus.Service(
                 name, loop, bus, replace_existing, allow_replacement,
-                name_queue
+                name_queue, thread_id
         )
         """Interface to sd-bus library"""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright: 2017, CCX Technologies
+# Copyright: 2017-2025, CCX Technologies
 """Test the method wrapper and decorators."""
 
 import unittest
@@ -38,6 +38,7 @@ class TestObject(adbus.server.Object):
     property1: str = adbus.server.Property('propertystring')
     property2: int = adbus.server.Property(100, emits_change=False)
     property3: typing.List[int] = adbus.server.Property([1, 2, 3])
+    property4: str = adbus.server.Property('hidden', hidden=True)
     datatype: TestDataType = adbus.server.Property(TestDataType(6))
 
     complex_type1: typing.Dict[str, str] = adbus.server.Property(
@@ -223,6 +224,7 @@ class Test(unittest.TestCase):
                 o.property1 = 'yellow'
                 o.property2 = 42
                 o.property3 = [6, 7, 10, 43, 102]
+                o.property4 = 'red'
 
             await self.delay(3)
 


### PR DESCRIPTION
The problem: If we schedule from a different thread, then it needs to be threadsafe. A thread safe call won't work from the same thread, it needs to be another thread.

Solution: logic from ccxdaemon to check thread https://github.com/ccxtechnologies/ccxdaemon/blob/b1e9cf78ebbc7ec7ae2097adab4324637d90ea88/ccxdaemon/object.py#L1354-L1378

If we create the loop in adbus, we can easily just get the thread id. However loop is an arg that we set in ccxdaemon, and uvloop does not have _thread_id attribute.
https://github.com/ccxtechnologies/ccxdaemon/blob/b1e9cf78ebbc7ec7ae2097adab4324637d90ea88/ccxdaemon/daemon.py#L228-L235