### PR TITLE
start adding support for object manager signals

### DIFF
--- a/adbus/__version__.py
+++ b/adbus/__version__.py
@@ -1,3 +1,3 @@
-# == Copyright: 2017-2025, CCX Technologies
+# == Copyright: 2017-2026, CCX Technologies
 
-__version__ = "1.2.9"
+__version__ = "1.3.0"

--- a/adbus/sdbus/manager.pxi
+++ b/adbus/sdbus/manager.pxi
@@ -1,4 +1,4 @@
-# == Copyright: 2017, CCX Technologies
+# == Copyright: 2017-2026, CCX Technologies
 #cython: language_level=3
 
 cdef class Manager:
@@ -13,6 +13,56 @@ cdef class Manager:
         ret = sdbus_h.sd_bus_add_object_manager(self.bus, &self._slot, self.path)
         if ret < 0:
             raise SdbusError(f"Failed to add manager: {errorcode[-ret]}", -ret)
+
+    def emit_interfaces_added(self, path, interfaces):
+        cdef int ret
+        cdef bytes b_path = path.encode()
+        cdef list b_interfaces = [i.encode() for i in interfaces]
+        cdef char **c_interfaces = <char **>PyMem_Malloc((len(b_interfaces) + 1) * sizeof(char *))
+
+        try:
+            for idx, iface in enumerate(b_interfaces):
+                c_interfaces[idx] = iface
+            c_interfaces[len(b_interfaces)] = NULL
+
+            ret = sdbus_h.sd_bus_emit_interfaces_added_strv(
+                self.bus, b_path, c_interfaces
+            )
+            if ret < 0:
+                raise SdbusError(f"Failed to emit InterfacesAdded: {errorcode[-ret]}", -ret)
+        finally:
+            PyMem_Free(c_interfaces)
+
+    def emit_interfaces_removed(self, path, interfaces):
+        cdef int ret
+        cdef bytes b_path = path.encode()
+        cdef list b_interfaces = [i.encode() for i in interfaces]
+        cdef char **c_interfaces = <char **>PyMem_Malloc((len(b_interfaces) + 1) * sizeof(char *))
+
+        try:
+            for idx, iface in enumerate(b_interfaces):
+                c_interfaces[idx] = iface
+            c_interfaces[len(b_interfaces)] = NULL
+
+            ret = sdbus_h.sd_bus_emit_interfaces_removed_strv(
+                self.bus, b_path, c_interfaces
+            )
+            if ret < 0:
+                raise SdbusError(f"Failed to emit InterfacesRemoved: {errorcode[-ret]}", -ret)
+        finally:
+            PyMem_Free(c_interfaces)
+
+    def emit_object_added(self, path):
+        cdef bytes b_path = path.encode()
+        cdef int ret = sdbus_h.sd_bus_emit_object_added(self.bus, b_path)
+        if ret < 0:
+            raise SdbusError(f"Failed to emit ObjectAdded: {errorcode[-ret]}", -ret)
+
+    def emit_object_removed(self, path):
+        cdef bytes b_path = path.encode()
+        cdef int ret = sdbus_h.sd_bus_emit_object_removed(self.bus, b_path)
+        if ret < 0:
+            raise SdbusError(f"Failed to emit ObjectRemoved: {errorcode[-ret]}", -ret)
 
     def __dealloc__(self):
         self._slot = sdbus_h.sd_bus_slot_unref(self._slot)

--- a/adbus/sdbus_h.pxd
+++ b/adbus/sdbus_h.pxd
@@ -1,4 +1,4 @@
-# Copyright: 2017, CCX Technologies
+# Copyright: 2017-2026, CCX Technologies
 #cython: language_level=3
 
 from libc cimport stdint
@@ -177,3 +177,10 @@ cdef extern from "systemd/sd-bus.h":
 
     int sd_bus_add_match(sd_bus *bus, sd_bus_slot **slot, const char *match,
             sd_bus_message_handler_t callback, void *userdata)
+
+    int sd_bus_emit_interfaces_added_strv(sd_bus *bus, const char *path,
+            char **interfaces)
+    int sd_bus_emit_interfaces_removed_strv(sd_bus *bus, const char *path,
+            char **interfaces)
+    int sd_bus_emit_object_added(sd_bus *bus, const char *path)
+    int sd_bus_emit_object_removed(sd_bus *bus, const char *path)

--- a/adbus/server/object.py
+++ b/adbus/server/object.py
@@ -1,4 +1,4 @@
-# Copyright: 2017-2025, CCX Technologies
+# Copyright: 2017-2026, CCX Technologies
 """D-Bus Object"""
 
 import asyncio
@@ -72,6 +72,8 @@ class Object:
 
         if manager:
             self.manager = sdbus.Manager(service.sdbus, path)
+        else:
+            self.manager = None
 
     def emit_property_changed(self, dbus_name):
         if self._defer_properties:
@@ -127,6 +129,54 @@ class Object:
                     )
 
                 self._deferred_property_signals = {}
+
+    def emit_interfaces_added(self, path, interfaces):
+        if self.manager is not None and self.service.is_running():
+            _loop = self.service.get_loop()
+            if _loop._ccx_thread_id != threading.get_ident():
+
+                async def _emit():
+                    self.manager.emit_interfaces_added(path, interfaces)
+
+                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+            else:
+                self.manager.emit_interfaces_added(path, interfaces)
+
+    def emit_interfaces_removed(self, path, interfaces):
+        if self.manager is not None and self.service.is_running():
+            _loop = self.service.get_loop()
+            if _loop._ccx_thread_id != threading.get_ident():
+
+                async def _emit():
+                    self.manager.emit_interfaces_removed(path, interfaces)
+
+                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+            else:
+                self.manager.emit_interfaces_removed(path, interfaces)
+
+    def emit_object_added(self, path):
+        if self.manager is not None and self.service.is_running():
+            _loop = self.service.get_loop()
+            if _loop._ccx_thread_id != threading.get_ident():
+
+                async def _emit():
+                    self.manager.emit_object_added(path)
+
+                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+            else:
+                self.manager.emit_object_added(path)
+
+    def emit_object_removed(self, path):
+        if self.manager is not None and self.service.is_running():
+            _loop = self.service.get_loop()
+            if _loop._ccx_thread_id != threading.get_ident():
+
+                async def _emit():
+                    self.manager.emit_object_removed(path)
+
+                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+            else:
+                self.manager.emit_object_removed(path)
 
     def detach(self):
         self.sdbus.detach()

--- a/adbus/server/object.py
+++ b/adbus/server/object.py
@@ -134,11 +134,9 @@ class Object:
         if self.manager is not None and self.service.is_running():
             _loop = self.service.get_loop()
             if _loop._ccx_thread_id != threading.get_ident():
-
-                async def _emit():
-                    self.manager.emit_interfaces_added(path, interfaces)
-
-                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+                _loop.call_soon_threadsafe(
+                        self.manager.emit_interfaces_added, path, interfaces
+                )
             else:
                 self.manager.emit_interfaces_added(path, interfaces)
 
@@ -146,11 +144,9 @@ class Object:
         if self.manager is not None and self.service.is_running():
             _loop = self.service.get_loop()
             if _loop._ccx_thread_id != threading.get_ident():
-
-                async def _emit():
-                    self.manager.emit_interfaces_removed(path, interfaces)
-
-                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+                _loop.call_soon_threadsafe(
+                        self.manager.emit_interfaces_removed, path, interfaces
+                )
             else:
                 self.manager.emit_interfaces_removed(path, interfaces)
 
@@ -158,11 +154,9 @@ class Object:
         if self.manager is not None and self.service.is_running():
             _loop = self.service.get_loop()
             if _loop._ccx_thread_id != threading.get_ident():
-
-                async def _emit():
-                    self.manager.emit_object_added(path)
-
-                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+                _loop.call_soon_threadsafe(
+                        self.manager.emit_object_added, path
+                )
             else:
                 self.manager.emit_object_added(path)
 
@@ -170,11 +164,9 @@ class Object:
         if self.manager is not None and self.service.is_running():
             _loop = self.service.get_loop()
             if _loop._ccx_thread_id != threading.get_ident():
-
-                async def _emit():
-                    self.manager.emit_object_removed(path)
-
-                asyncio.run_coroutine_threadsafe(_emit(), _loop).result()
+                _loop.call_soon_threadsafe(
+                        self.manager.emit_object_removed, path
+                )
             else:
                 self.manager.emit_object_removed(path)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+# Copyright: 2026, CCX Technologies
+"""Test the ObjectManager implementation and signal emissions."""
+
+import unittest
+import asyncio
+import time
+from multiprocessing import Process
+
+import adbus
+
+service_name = 'adbus.test.manager'
+object_path = '/adbus/test/Manager'
+object_interface = 'adbus.test.manager'
+
+
+class ManagerTestObject(adbus.server.Object):
+
+    def __init__(self, service):
+        super().__init__(service, object_path, object_interface, manager=True)
+
+    @adbus.server.method()
+    def trigger_object_manager(self) -> None:
+        """Trigger explicit interface emissions to test the manager."""
+        child_path = object_path + '/TestChild'
+
+        # sd-bus requires an object to actually exist in its internal registry
+        # before it can emit InterfacesAdded (it needs to query its properties).
+        child = adbus.server.Object(self.service, child_path, object_interface)
+
+        # Test emitting interfaces added and removed
+        self.manager.emit_interfaces_added(child_path, [object_interface])
+        self.manager.emit_interfaces_removed(child_path, [object_interface])
+
+        # Test emitting full object added and removed
+        self.manager.emit_object_added(child_path)
+        self.manager.emit_object_removed(child_path)
+
+        # Clean up by detaching the object
+        child.detach()
+
+
+def run_server():
+    """Run the test server in a separate process."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    service = adbus.Service(
+            service_name,
+            bus='session',
+            replace_existing=True,
+            allow_replacement=True
+    )
+
+    # Instantiate the object to attach it to the service
+    obj = ManagerTestObject(service)
+
+    async def serve():
+        while True:
+            await asyncio.sleep(1)
+
+    try:
+        loop.run_until_complete(serve())
+    except KeyboardInterrupt:
+        pass
+
+
+class TestObjectManager(unittest.TestCase):
+    """Test ObjectManager signal listeners and emitters."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Start the server process
+        cls.server = Process(target=run_server, name='run_manager_server')
+        cls.server.start()
+
+        # Give the server a moment to register on the D-Bus
+        time.sleep(2)
+
+        cls.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(cls.loop)
+        cls.service = adbus.Service(bus='session')
+
+    @classmethod
+    def tearDownClass(cls):
+        # Terminate the background server process
+        cls.server.terminate()
+        cls.server.join()
+        cls.loop.close()
+
+    def test_manager_signals(self):
+        signals_received = []
+
+        # When signature is explicitly provided, adbus passes a single list of arguments
+        async def added_cb(args):
+            path, interfaces = args
+            signals_received.append(("InterfacesAdded", path))
+            print(f"ObjectManager: Received InterfacesAdded for {path}")
+
+        async def removed_cb(args):
+            path, interfaces = args
+            signals_received.append(("InterfacesRemoved", path))
+            print(f"ObjectManager: Received InterfacesRemoved for {path}")
+
+        async def _test():
+            # Setup listeners for standard ObjectManager signals
+            listen_add = adbus.client.Listen(
+                    self.service,
+                    service_name,
+                    object_path,
+                    "org.freedesktop.DBus.ObjectManager",
+                    "InterfacesAdded",
+                    added_cb,
+                    signature="oa{sa{sv}}"
+            )
+            listen_rem = adbus.client.Listen(
+                    self.service,
+                    service_name,
+                    object_path,
+                    "org.freedesktop.DBus.ObjectManager",
+                    "InterfacesRemoved",
+                    removed_cb,
+                    signature="oas"
+            )
+
+            # Call the server method to trigger the emissions
+            print("Triggering ObjectManager emissions...")
+            await adbus.client.call(
+                    self.service, service_name, object_path, object_interface,
+                    "TriggerObjectManager"
+            )
+
+            # Give the bus time to propagate the signals back to our client listeners
+            await asyncio.sleep(1)
+
+        self.loop.run_until_complete(_test())
+
+        # Verify that we actually received the signals sent by the server
+        self.assertTrue(
+                len(signals_received) > 0,
+                "Failed to receive ObjectManager signals"
+        )
+
+        added_count = sum(
+                1 for s in signals_received if s[0] == "InterfacesAdded"
+        )
+        removed_count = sum(
+                1 for s in signals_received if s[0] == "InterfacesRemoved"
+        )
+
+        # Verify both add and remove signals were intercepted
+        self.assertGreaterEqual(added_count, 1)
+        self.assertGreaterEqual(removed_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright: 2026, CCX Technologies
-"""Test the ObjectManager implementation and signal emissions."""
+"""Test the ObjectManager wrapper methods on adbus.server.Object."""
 
 import unittest
 import asyncio
@@ -9,40 +9,43 @@ import time
 from multiprocessing import Process
 
 import adbus
+import adbus.server
+import adbus.client
 
-service_name = 'adbus.test.manager'
+service_name = 'adbus.test.objectmanager'
 object_path = '/adbus/test/Manager'
 object_interface = 'adbus.test.manager'
 
 
 class ManagerTestObject(adbus.server.Object):
+    """Test object initialized with an ObjectManager attached."""
 
     def __init__(self, service):
+        # Setting manager=True initializes the underlying sdbus.Manager
         super().__init__(service, object_path, object_interface, manager=True)
 
     @adbus.server.method()
-    def trigger_object_manager(self) -> None:
-        """Trigger explicit interface emissions to test the manager."""
+    def trigger_emissions(self) -> None:
+        """Trigger explicit interface emissions using the new wrapper methods."""
         child_path = object_path + '/TestChild'
 
         # sd-bus requires an object to actually exist in its internal registry
         # before it can emit InterfacesAdded (it needs to query its properties).
         child = adbus.server.Object(self.service, child_path, object_interface)
 
-        # Test emitting interfaces added and removed
-        self.manager.emit_interfaces_added(child_path, [object_interface])
-        self.manager.emit_interfaces_removed(child_path, [object_interface])
+        # Test the wrapper methods directly on the Object instance
+        self.emit_interfaces_added(child_path, [object_interface])
+        self.emit_interfaces_removed(child_path, [object_interface])
 
-        # Test emitting full object added and removed
-        self.manager.emit_object_added(child_path)
-        self.manager.emit_object_removed(child_path)
+        self.emit_object_added(child_path)
+        self.emit_object_removed(child_path)
 
-        # Clean up by detaching the object
+        # Clean up by detaching the mock child object
         child.detach()
 
 
 def run_server():
-    """Run the test server in a separate process."""
+    """Run the test server in a separate background process."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
@@ -53,7 +56,7 @@ def run_server():
             allow_replacement=True
     )
 
-    # Instantiate the object to attach it to the service
+    # Instantiate the root object (which has manager=True)
     obj = ManagerTestObject(service)
 
     async def serve():
@@ -66,16 +69,16 @@ def run_server():
         pass
 
 
-class TestObjectManager(unittest.TestCase):
-    """Test ObjectManager signal listeners and emitters."""
+class TestObjectManagerWrapper(unittest.TestCase):
+    """Test ObjectManager signal wrapper methods on adbus.server.Object."""
 
     @classmethod
     def setUpClass(cls):
-        # Start the server process
+        # 1. Start the server daemon process
         cls.server = Process(target=run_server, name='run_manager_server')
         cls.server.start()
 
-        # Give the server a moment to register on the D-Bus
+        # Give the server a moment to attach its DBus connection
         time.sleep(2)
 
         cls.loop = asyncio.new_event_loop()
@@ -84,24 +87,23 @@ class TestObjectManager(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # Terminate the background server process
+        # 2. Terminate the background server process
         cls.server.terminate()
         cls.server.join()
         cls.loop.close()
 
-    def test_manager_signals(self):
+    def test_manager_wrapper_signals(self):
         signals_received = []
 
-        # When signature is explicitly provided, adbus passes a single list of arguments
         async def added_cb(args):
             path, interfaces = args
             signals_received.append(("InterfacesAdded", path))
-            print(f"ObjectManager: Received InterfacesAdded for {path}")
+            print(f"Signal Received: InterfacesAdded for {path}")
 
         async def removed_cb(args):
             path, interfaces = args
             signals_received.append(("InterfacesRemoved", path))
-            print(f"ObjectManager: Received InterfacesRemoved for {path}")
+            print(f"Signal Received: InterfacesRemoved for {path}")
 
         async def _test():
             # Setup listeners for standard ObjectManager signals
@@ -114,6 +116,7 @@ class TestObjectManager(unittest.TestCase):
                     added_cb,
                     signature="oa{sa{sv}}"
             )
+
             listen_rem = adbus.client.Listen(
                     self.service,
                     service_name,
@@ -124,11 +127,13 @@ class TestObjectManager(unittest.TestCase):
                     signature="oas"
             )
 
-            # Call the server method to trigger the emissions
-            print("Triggering ObjectManager emissions...")
+            # Call the server method to trigger the wrapper emissions
+            print(
+                    "Triggering ObjectManager emissions via adbus.server.Object wrappers..."
+            )
             await adbus.client.call(
                     self.service, service_name, object_path, object_interface,
-                    "TriggerObjectManager"
+                    "TriggerEmissions"
             )
 
             # Give the bus time to propagate the signals back to our client listeners
@@ -136,7 +141,7 @@ class TestObjectManager(unittest.TestCase):
 
         self.loop.run_until_complete(_test())
 
-        # Verify that we actually received the signals sent by the server
+        # Verify that we actually received the signals dispatched by the wrapper methods
         self.assertTrue(
                 len(signals_received) > 0,
                 "Failed to receive ObjectManager signals"
@@ -149,9 +154,15 @@ class TestObjectManager(unittest.TestCase):
                 1 for s in signals_received if s[0] == "InterfacesRemoved"
         )
 
-        # Verify both add and remove signals were intercepted
-        self.assertGreaterEqual(added_count, 1)
-        self.assertGreaterEqual(removed_count, 1)
+        # Assert we caught the signals
+        self.assertGreaterEqual(
+                added_count, 1,
+                "Failed to receive InterfacesAdded signal via wrapper"
+        )
+        self.assertGreaterEqual(
+                removed_count, 1,
+                "Failed to receive InterfacesRemoved signal via wrapper"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For https://github.com/ccxtechnologies/builder/issues/2601
```
❯ python tests/test_manager.py
Triggering ObjectManager emissions via adbus.server.Object wrappers...
Signal Received: InterfacesAdded for /adbus/test/Manager/TestChild
Signal Received: InterfacesRemoved for /adbus/test/Manager/TestChild
Signal Received: InterfacesAdded for /adbus/test/Manager/TestChild
Signal Received: InterfacesRemoved for /adbus/test/Manager/TestChild
.
----------------------------------------------------------------------
Ran 1 test in 3.028s

OK
```
```
❯ dbus-monitor --session "interface='org.freedesktop.DBus.ObjectManager'"
signal time=1776803982.341853 sender=org.freedesktop.DBus -> destination=:1.8 serial=4294967295 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameAcquired
   string ":1.8"
signal time=1776803982.341923 sender=org.freedesktop.DBus -> destination=:1.8 serial=4294967295 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameLost
   string ":1.8"
signal time=1776804019.304533 sender=:1.9 -> destination=(null destination) serial=3 path=/adbus/test/Manager; interface=org.freedesktop.DBus.ObjectManager; member=InterfacesAdded
   object path "/adbus/test/Manager/TestChild"
   array [
      dict entry(
         string "adbus.test.manager"
         array [
         ]
      )
   ]
signal time=1776804019.305211 sender=:1.9 -> destination=(null destination) serial=4 path=/adbus/test/Manager; interface=org.freedesktop.DBus.ObjectManager; member=InterfacesRemoved
   object path "/adbus/test/Manager/TestChild"
   array [
      string "adbus.test.manager"
   ]
signal time=1776804019.305794 sender=:1.9 -> destination=(null destination) serial=5 path=/adbus/test/Manager; interface=org.freedesktop.DBus.ObjectManager; member=InterfacesAdded
   object path "/adbus/test/Manager/TestChild"
   array [
      dict entry(
         string "org.freedesktop.DBus.Peer"
         array [
         ]
      )
      dict entry(
         string "org.freedesktop.DBus.Introspectable"
         array [
         ]
      )
      dict entry(
         string "org.freedesktop.DBus.Properties"
         array [
         ]
      )
      dict entry(
         string "adbus.test.manager"
         array [
         ]
      )
   ]
signal time=1776804019.306339 sender=:1.9 -> destination=(null destination) serial=6 path=/adbus/test/Manager; interface=org.freedesktop.DBus.ObjectManager; member=InterfacesRemoved
   object path "/adbus/test/Manager/TestChild"
   array [
      string "org.freedesktop.DBus.Peer"
      string "org.freedesktop.DBus.Introspectable"
      string "org.freedesktop.DBus.Properties"
      string "adbus.test.manager"
   ]
```